### PR TITLE
add rustflags for linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 *.pyc
-.idea/
 
 build_artifacts

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.pyc
+.idea/
 
 build_artifacts

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,6 +2,11 @@
 
 set -ex
 
+if [[ "${target_platform}" == "linux-64" ]]; then
+  # similar to settings upstream in polars
+  export RUSTFLAGS='-C target-feature=+fxsr,+sse,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+avx,+fma'
+fi
+
 maturin build --no-sdist --release --strip --manylinux off --interpreter="${PYTHON}"
 
 "${PYTHON}" -m pip install $SRC_DIR/target/wheels/polars*.whl --no-deps -vv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
     sha256: f36388b05e7c9dddee9207f7bc97d5a58e9e0a268c03b8d5bfec5091612cec4c
 
 build:
-  number: 1
+  number: 2
   # Todo: uncomment win skipping when fixing: https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=505331&view=logs&j=240f1fee-52bc-5498-a14a-8361bde76ba0&t=06d62fd2-ab49-5add-9ee5-83b6882d7d2b&l=2215
   skip: true  # [py<37 or win]
 


### PR DESCRIPTION

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Add the same rustflags we use upstream in pypi releases. This should make the binaries for end users similar.