### PR TITLE
Fix Polars 0.13.58 build and newer.

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -5,7 +5,7 @@
 jobs:
 - job: osx
   pool:
-    vmImage: macOS-10.15
+    vmImage: macOS-11
   strategy:
     matrix:
       osx_64_python3.10.____cpython:

--- a/.ci_support/linux_64_python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_python3.10.____cpython.yaml
@@ -18,5 +18,7 @@ python:
 - 3.10.* *_cpython
 rust_compiler:
 - rust
+rust_compiler_version:
+- '1.63'
 target_platform:
 - linux-64

--- a/.ci_support/linux_64_python3.7.____cpython.yaml
+++ b/.ci_support/linux_64_python3.7.____cpython.yaml
@@ -18,5 +18,7 @@ python:
 - 3.7.* *_cpython
 rust_compiler:
 - rust
+rust_compiler_version:
+- '1.63'
 target_platform:
 - linux-64

--- a/.ci_support/linux_64_python3.8.____73_pypy.yaml
+++ b/.ci_support/linux_64_python3.8.____73_pypy.yaml
@@ -18,5 +18,7 @@ python:
 - 3.8.* *_73_pypy
 rust_compiler:
 - rust
+rust_compiler_version:
+- '1.63'
 target_platform:
 - linux-64

--- a/.ci_support/linux_64_python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_python3.8.____cpython.yaml
@@ -18,5 +18,7 @@ python:
 - 3.8.* *_cpython
 rust_compiler:
 - rust
+rust_compiler_version:
+- '1.63'
 target_platform:
 - linux-64

--- a/.ci_support/linux_64_python3.9.____73_pypy.yaml
+++ b/.ci_support/linux_64_python3.9.____73_pypy.yaml
@@ -18,5 +18,7 @@ python:
 - 3.9.* *_73_pypy
 rust_compiler:
 - rust
+rust_compiler_version:
+- '1.63'
 target_platform:
 - linux-64

--- a/.ci_support/linux_64_python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_python3.9.____cpython.yaml
@@ -18,5 +18,7 @@ python:
 - 3.9.* *_cpython
 rust_compiler:
 - rust
+rust_compiler_version:
+- '1.63'
 target_platform:
 - linux-64

--- a/.ci_support/osx_64_python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_python3.10.____cpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '13'
+- '14'
 channel_sources:
 - conda-forge/label/rust_dev,conda-forge
 channel_targets:
@@ -18,5 +18,7 @@ python:
 - 3.10.* *_cpython
 rust_compiler:
 - rust
+rust_compiler_version:
+- '1.63'
 target_platform:
 - osx-64

--- a/.ci_support/osx_64_python3.7.____cpython.yaml
+++ b/.ci_support/osx_64_python3.7.____cpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '13'
+- '14'
 channel_sources:
 - conda-forge/label/rust_dev,conda-forge
 channel_targets:
@@ -18,5 +18,7 @@ python:
 - 3.7.* *_cpython
 rust_compiler:
 - rust
+rust_compiler_version:
+- '1.63'
 target_platform:
 - osx-64

--- a/.ci_support/osx_64_python3.8.____73_pypy.yaml
+++ b/.ci_support/osx_64_python3.8.____73_pypy.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '13'
+- '14'
 channel_sources:
 - conda-forge/label/rust_dev,conda-forge
 channel_targets:
@@ -18,5 +18,7 @@ python:
 - 3.8.* *_73_pypy
 rust_compiler:
 - rust
+rust_compiler_version:
+- '1.63'
 target_platform:
 - osx-64

--- a/.ci_support/osx_64_python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_python3.8.____cpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '13'
+- '14'
 channel_sources:
 - conda-forge/label/rust_dev,conda-forge
 channel_targets:
@@ -18,5 +18,7 @@ python:
 - 3.8.* *_cpython
 rust_compiler:
 - rust
+rust_compiler_version:
+- '1.63'
 target_platform:
 - osx-64

--- a/.ci_support/osx_64_python3.9.____73_pypy.yaml
+++ b/.ci_support/osx_64_python3.9.____73_pypy.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '13'
+- '14'
 channel_sources:
 - conda-forge/label/rust_dev,conda-forge
 channel_targets:
@@ -18,5 +18,7 @@ python:
 - 3.9.* *_73_pypy
 rust_compiler:
 - rust
+rust_compiler_version:
+- '1.63'
 target_platform:
 - osx-64

--- a/.ci_support/osx_64_python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_python3.9.____cpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '13'
+- '14'
 channel_sources:
 - conda-forge/label/rust_dev,conda-forge
 channel_targets:
@@ -18,5 +18,7 @@ python:
 - 3.9.* *_cpython
 rust_compiler:
 - rust
+rust_compiler_version:
+- '1.63'
 target_platform:
 - osx-64

--- a/.ci_support/osx_arm64_python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.10.____cpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '13'
+- '14'
 channel_sources:
 - conda-forge/label/rust_dev,conda-forge
 channel_targets:
@@ -18,5 +18,7 @@ python:
 - 3.10.* *_cpython
 rust_compiler:
 - rust
+rust_compiler_version:
+- '1.63'
 target_platform:
 - osx-arm64

--- a/.ci_support/osx_arm64_python3.8.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.8.____cpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '13'
+- '14'
 channel_sources:
 - conda-forge/label/rust_dev,conda-forge
 channel_targets:
@@ -18,5 +18,7 @@ python:
 - 3.8.* *_cpython
 rust_compiler:
 - rust
+rust_compiler_version:
+- '1.63'
 target_platform:
 - osx-arm64

--- a/.ci_support/osx_arm64_python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.9.____cpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '13'
+- '14'
 channel_sources:
 - conda-forge/label/rust_dev,conda-forge
 channel_targets:
@@ -18,5 +18,7 @@ python:
 - 3.9.* *_cpython
 rust_compiler:
 - rust
+rust_compiler_version:
+- '1.63'
 target_platform:
 - osx-arm64

--- a/.ci_support/win_64_python3.10.____cpython.yaml
+++ b/.ci_support/win_64_python3.10.____cpython.yaml
@@ -12,5 +12,7 @@ python:
 - 3.10.* *_cpython
 rust_compiler:
 - rust
+rust_compiler_version:
+- '1.63'
 target_platform:
 - win-64

--- a/.ci_support/win_64_python3.7.____cpython.yaml
+++ b/.ci_support/win_64_python3.7.____cpython.yaml
@@ -12,5 +12,7 @@ python:
 - 3.7.* *_cpython
 rust_compiler:
 - rust
+rust_compiler_version:
+- '1.63'
 target_platform:
 - win-64

--- a/.ci_support/win_64_python3.8.____73_pypy.yaml
+++ b/.ci_support/win_64_python3.8.____73_pypy.yaml
@@ -12,5 +12,7 @@ python:
 - 3.8.* *_73_pypy
 rust_compiler:
 - rust
+rust_compiler_version:
+- '1.63'
 target_platform:
 - win-64

--- a/.ci_support/win_64_python3.8.____cpython.yaml
+++ b/.ci_support/win_64_python3.8.____cpython.yaml
@@ -12,5 +12,7 @@ python:
 - 3.8.* *_cpython
 rust_compiler:
 - rust
+rust_compiler_version:
+- '1.63'
 target_platform:
 - win-64

--- a/.ci_support/win_64_python3.9.____73_pypy.yaml
+++ b/.ci_support/win_64_python3.9.____73_pypy.yaml
@@ -12,5 +12,7 @@ python:
 - 3.9.* *_73_pypy
 rust_compiler:
 - rust
+rust_compiler_version:
+- '1.63'
 target_platform:
 - win-64

--- a/.ci_support/win_64_python3.9.____cpython.yaml
+++ b/.ci_support/win_64_python3.9.____cpython.yaml
@@ -12,5 +12,7 @@ python:
 - 3.9.* *_cpython
 rust_compiler:
 - rust
+rust_compiler_version:
+- '1.63'
 target_platform:
 - win-64

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,7 +1,7 @@
 set "PYO3_PYTHON=%PYTHON%"
 
 set "CMAKE_GENERATOR=NMake Makefiles"
-maturin build --no-sdist --release --strip --manylinux off --interpreter=%PYTHON%
+maturin build --release --strip --manylinux off --interpreter=%PYTHON%
 if errorlevel 1 exit 1
 
 FOR /F "delims=" %%i IN ('dir /s /b target\wheels\*.whl') DO set polars_wheel=%%i

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -7,7 +7,7 @@ if [[ "${target_platform}" == "linux-64" ]]; then
   export RUSTFLAGS='-C target-feature=+fxsr,+sse,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+avx,+fma'
 fi
 
-maturin build --no-sdist --release --strip --manylinux off --interpreter="${PYTHON}"
+maturin build --release --strip --manylinux off --interpreter="${PYTHON}"
 
 "${PYTHON}" -m pip install $SRC_DIR/target/wheels/polars*.whl --no-deps -vv
 

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,5 +1,12 @@
 c_compiler:  # [win]
-- vs2019  # [win]
+  - vs2019  # [win]
+
+rust_compiler:
+  - rust
+rust_compiler_version:
+  - 1.63
 
 channel_sources:
- - conda-forge/label/rust_dev,conda-forge
+  - conda-forge/label/rust_dev,conda-forge
+channel_targets:
+  - conda-forge main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ requirements:
   host:
     - python
     - pip
-    - maturin >=0.12.11,<0.13
+    - maturin >=0.13,<0.14
   run:
     - python
     - numpy >=1.16.0


### PR DESCRIPTION
Fix Polars 0.13.58 build and newer:
  - Update rust from 1.61.0 to 1.63.0.
  - Update maturin to =0.13,<0.14 which does not
    build source distributions by default anymore.
