### PR TITLE
Decrease `codegen-units` for Windows builds to decrease memory consumption

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,7 +1,7 @@
 set "PYO3_PYTHON=%PYTHON%"
 
 set "CMAKE_GENERATOR=NMake Makefiles"
-set "RUSTFLAGS=-C codegen-units=2"
+set "RUSTFLAGS=-C codegen-units=1"
 maturin build -v --jobs 1 --release --strip --manylinux off --interpreter=%PYTHON%
 if errorlevel 1 exit 1
 

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,7 +1,7 @@
 set "PYO3_PYTHON=%PYTHON%"
 
 set "CMAKE_GENERATOR=NMake Makefiles"
-set "RUSTFLAGS=-C codegen-units=4"
+set "RUSTFLAGS=-C codegen-units=2"
 maturin build -v --jobs 1 --release --strip --manylinux off --interpreter=%PYTHON%
 if errorlevel 1 exit 1
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
     sha256: f121ad3515dfc4c0276067870c20585f5e4fa8368efc9cf7ff8c56da4372e312
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<37]
   skip: true  # [win and python_impl=="pypy"]
 


### PR DESCRIPTION
Might resolve #95?

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
