### PR TITLE
Fix libz-ng-sys patch for Polars >= 1.18.0

### DIFF
--- a/recipe/0001-Patch-libz-ng-sys.patch
+++ b/recipe/0001-Patch-libz-ng-sys.patch
@@ -14,14 +14,12 @@ diff --git a/Cargo.toml b/Cargo.toml
 index cd37103..1a09b4d 100644
 --- a/Cargo.toml
 +++ b/Cargo.toml
-@@ -132,6 +132,7 @@ features = [
+@@ -131,4 +131,5 @@ features = [
+ 
  [patch.crates-io]
++libz-ng-sys = { path = './py-polars/target/patch/libz-ng-sys-1.1.20/' }
  # packed_simd_2 = { git = "https://github.com/rust-lang/packed_simd", rev = "e57c7ba11386147e6d2cbad7c88f376aab4bdc86" }
  # simd-json = { git = "https://github.com/ritchie46/simd-json", branch = "alignment" }
-+libz-ng-sys = { path = './py-polars/target/patch/libz-ng-sys-1.1.20/' }
- 
- [profile.mindebug-dev]
- inherits = "dev"
 diff --git a/py-polars/0001-not-mingw.patch b/py-polars/0001-not-mingw.patch
 new file mode 100644
 index 0000000..c194eda

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ source:
 
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Polars 1.18.0 added some entries in `[patch.crates-io]` section of `Cargo.toml` such that `recipe/0001-Patch-libz-ng-sys.patch` can't be applied anymore. Update the patch so it is applicable for both Polars < 1.18.0 and Polars >= 1.18.0.
