### PR TITLE
Only strip debuginfo not symbols

### DIFF
--- a/recipe/build_polars_runtime.sh
+++ b/recipe/build_polars_runtime.sh
@@ -8,7 +8,7 @@ cd $PKG_NAME
 mkdir -p ${BUILD_PREFIX}/bin
 cp ${RECIPE_DIR}/cargo-auditable-wrapper.sh ${BUILD_PREFIX}/bin/cargo-auditable-wrapper
 export CARGO="cargo-auditable-wrapper"
-export CARGO_PROFILE_RELEASE_STRIP=symbols
+export CARGO_PROFILE_RELEASE_STRIP=debuginfo
 
 # see https://github.com/pola-rs/polars/blob/main/.github/workflows/release-python.yml
 COMPAT_TUNE_CPU=''


### PR DESCRIPTION
Per https://doc.rust-lang.org/rustc/codegen-options/index.html#strip, only stripping debuginfo should allow backtraces to symbolicated. We originally started stripping due to large library sizes (https://github.com/conda-forge/polars-feedstock/issues/292), this increases the shared object size by ~150mb on linux. Is that acceptable?
xerf https://github.com/conda-forge/polars-feedstock/issues/367

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
