### PR TITLE
Backport rustls-webpki bump from polars#27382

### DIFF
--- a/recipe/0001-bump-rustls-webpki.patch
+++ b/recipe/0001-bump-rustls-webpki.patch
@@ -1,0 +1,372 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index 838c70ea4a03..651baef0570e 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -352,6 +352,7 @@ dependencies = [
+  "http 0.2.12",
+  "http 1.4.0",
+  "http-body 0.4.6",
++ "http-body 1.0.1",
+  "lru",
+  "percent-encoding",
+  "regex-lite",
+@@ -596,23 +597,17 @@ dependencies = [
+  "aws-smithy-async",
+  "aws-smithy-runtime-api",
+  "aws-smithy-types",
+- "h2 0.3.27",
+- "h2 0.4.13",
+- "http 0.2.12",
++ "h2",
+  "http 1.4.0",
+- "http-body 0.4.6",
+- "hyper 0.14.32",
+- "hyper 1.8.1",
+- "hyper-rustls 0.24.2",
+- "hyper-rustls 0.27.7",
++ "hyper",
++ "hyper-rustls",
+  "hyper-util",
+  "pin-project-lite",
+- "rustls 0.21.12",
+- "rustls 0.23.36",
++ "rustls",
+  "rustls-native-certs",
+  "rustls-pki-types",
+  "tokio",
+- "tokio-rustls 0.26.4",
++ "tokio-rustls",
+  "tower",
+  "tracing",
+ ]
+@@ -1716,25 +1711,6 @@ dependencies = [
+  "subtle",
+ ]
+ 
+-[[package]]
+-name = "h2"
+-version = "0.3.27"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
+-dependencies = [
+- "bytes",
+- "fnv",
+- "futures-core",
+- "futures-sink",
+- "futures-util",
+- "http 0.2.12",
+- "indexmap",
+- "slab",
+- "tokio",
+- "tokio-util",
+- "tracing",
+-]
+-
+ [[package]]
+ name = "h2"
+ version = "0.4.13"
+@@ -1894,42 +1870,12 @@ version = "1.10.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+ 
+-[[package]]
+-name = "httpdate"
+-version = "1.0.3"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+-
+ [[package]]
+ name = "humantime"
+ version = "2.3.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+ 
+-[[package]]
+-name = "hyper"
+-version = "0.14.32"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+-dependencies = [
+- "bytes",
+- "futures-channel",
+- "futures-core",
+- "futures-util",
+- "h2 0.3.27",
+- "http 0.2.12",
+- "http-body 0.4.6",
+- "httparse",
+- "httpdate",
+- "itoa",
+- "pin-project-lite",
+- "socket2 0.5.10",
+- "tokio",
+- "tower-service",
+- "tracing",
+- "want",
+-]
+-
+ [[package]]
+ name = "hyper"
+ version = "1.8.1"
+@@ -1940,7 +1886,7 @@ dependencies = [
+  "bytes",
+  "futures-channel",
+  "futures-core",
+- "h2 0.4.13",
++ "h2",
+  "http 1.4.0",
+  "http-body 1.0.1",
+  "httparse",
+@@ -1952,21 +1898,6 @@ dependencies = [
+  "want",
+ ]
+ 
+-[[package]]
+-name = "hyper-rustls"
+-version = "0.24.2"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+-dependencies = [
+- "futures-util",
+- "http 0.2.12",
+- "hyper 0.14.32",
+- "log",
+- "rustls 0.21.12",
+- "tokio",
+- "tokio-rustls 0.24.1",
+-]
+-
+ [[package]]
+ name = "hyper-rustls"
+ version = "0.27.7"
+@@ -1974,13 +1905,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+ dependencies = [
+  "http 1.4.0",
+- "hyper 1.8.1",
++ "hyper",
+  "hyper-util",
+- "rustls 0.23.36",
++ "rustls",
+  "rustls-native-certs",
+  "rustls-pki-types",
+  "tokio",
+- "tokio-rustls 0.26.4",
++ "tokio-rustls",
+  "tower-service",
+ ]
+ 
+@@ -1992,7 +1923,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+ dependencies = [
+  "bytes",
+  "http-body-util",
+- "hyper 1.8.1",
++ "hyper",
+  "hyper-util",
+  "native-tls",
+  "tokio",
+@@ -2012,12 +1943,12 @@ dependencies = [
+  "futures-util",
+  "http 1.4.0",
+  "http-body 1.0.1",
+- "hyper 1.8.1",
++ "hyper",
+  "ipnet",
+  "libc",
+  "percent-encoding",
+  "pin-project-lite",
+- "socket2 0.6.2",
++ "socket2",
+  "tokio",
+  "tower-service",
+  "tracing",
+@@ -2755,7 +2686,7 @@ dependencies = [
+  "http-body-util",
+  "httparse",
+  "humantime",
+- "hyper 1.8.1",
++ "hyper",
+  "itertools 0.14.0",
+  "md-5",
+  "parking_lot",
+@@ -3954,8 +3885,8 @@ dependencies = [
+  "quinn-proto",
+  "quinn-udp",
+  "rustc-hash",
+- "rustls 0.23.36",
+- "socket2 0.6.2",
++ "rustls",
++ "socket2",
+  "thiserror 2.0.18",
+  "tokio",
+  "tracing",
+@@ -3974,7 +3905,7 @@ dependencies = [
+  "rand 0.9.2",
+  "ring",
+  "rustc-hash",
+- "rustls 0.23.36",
++ "rustls",
+  "rustls-pki-types",
+  "slab",
+  "thiserror 2.0.18",
+@@ -3992,7 +3923,7 @@ dependencies = [
+  "cfg_aliases",
+  "libc",
+  "once_cell",
+- "socket2 0.6.2",
++ "socket2",
+  "tracing",
+  "windows-sys 0.60.2",
+ ]
+@@ -4220,12 +4151,12 @@ dependencies = [
+  "futures-channel",
+  "futures-core",
+  "futures-util",
+- "h2 0.4.13",
++ "h2",
+  "http 1.4.0",
+  "http-body 1.0.1",
+  "http-body-util",
+- "hyper 1.8.1",
+- "hyper-rustls 0.27.7",
++ "hyper",
++ "hyper-rustls",
+  "hyper-tls",
+  "hyper-util",
+  "js-sys",
+@@ -4234,7 +4165,7 @@ dependencies = [
+  "percent-encoding",
+  "pin-project-lite",
+  "quinn",
+- "rustls 0.23.36",
++ "rustls",
+  "rustls-native-certs",
+  "rustls-pki-types",
+  "serde",
+@@ -4243,7 +4174,7 @@ dependencies = [
+  "sync_wrapper",
+  "tokio",
+  "tokio-native-tls",
+- "tokio-rustls 0.26.4",
++ "tokio-rustls",
+  "tokio-util",
+  "tower",
+  "tower-http",
+@@ -4339,18 +4270,6 @@ dependencies = [
+  "windows-sys 0.61.2",
+ ]
+ 
+-[[package]]
+-name = "rustls"
+-version = "0.21.12"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+-dependencies = [
+- "log",
+- "ring",
+- "rustls-webpki 0.101.7",
+- "sct",
+-]
+-
+ [[package]]
+ name = "rustls"
+ version = "0.23.36"
+@@ -4361,7 +4280,7 @@ dependencies = [
+  "once_cell",
+  "ring",
+  "rustls-pki-types",
+- "rustls-webpki 0.103.9",
++ "rustls-webpki",
+  "subtle",
+  "zeroize",
+ ]
+@@ -4390,19 +4309,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "rustls-webpki"
+-version = "0.101.7"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+-dependencies = [
+- "ring",
+- "untrusted",
+-]
+-
+-[[package]]
+-name = "rustls-webpki"
+-version = "0.103.9"
++version = "0.103.13"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
++checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+ dependencies = [
+  "aws-lc-rs",
+  "ring",
+@@ -4474,16 +4383,6 @@ version = "1.2.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+ 
+-[[package]]
+-name = "sct"
+-version = "0.7.1"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+-dependencies = [
+- "ring",
+- "untrusted",
+-]
+-
+ [[package]]
+ name = "sec1"
+ version = "0.3.0"
+@@ -4757,16 +4656,6 @@ version = "1.1.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
+ 
+-[[package]]
+-name = "socket2"
+-version = "0.5.10"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+-dependencies = [
+- "libc",
+- "windows-sys 0.52.0",
+-]
+-
+ [[package]]
+ name = "socket2"
+ version = "0.6.2"
+@@ -5118,7 +5007,7 @@ dependencies = [
+  "mio",
+  "pin-project-lite",
+  "signal-hook-registry",
+- "socket2 0.6.2",
++ "socket2",
+  "tokio-macros",
+  "windows-sys 0.61.2",
+ ]
+@@ -5144,23 +5033,13 @@ dependencies = [
+  "tokio",
+ ]
+ 
+-[[package]]
+-name = "tokio-rustls"
+-version = "0.24.1"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+-dependencies = [
+- "rustls 0.21.12",
+- "tokio",
+-]
+-
+ [[package]]
+ name = "tokio-rustls"
+ version = "0.26.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+ dependencies = [
+- "rustls 0.23.36",
++ "rustls",
+  "tokio",
+ ]
+ 

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -16,19 +16,25 @@ source:
       - url: https://pypi.org/packages/source/p/polars-runtime-32/polars_runtime_32-${{ version }}.tar.gz
         sha256: 37f3065615d1bf90d03b5326222df4c5c1f8a5d33e50470aa588e3465e6eb814
         target_directory: polars-runtime-32
+        patches:
+          - 0001-bump-rustls-webpki.patch
   - if: polars_runtime == '64'
     then:
       url: https://pypi.org/packages/source/p/polars-runtime-64/polars_runtime_64-${{ version }}.tar.gz
       sha256: 7c05b5f3a11cfc2be7d12d0664664182381766b3a530f614b08fa01e19a83b25
       target_directory: polars-runtime-64
+      patches:
+        - 0001-bump-rustls-webpki.patch
   - if: polars_runtime == 'compat'
     then:
       url: https://pypi.org/packages/source/p/polars-runtime-compat/polars_runtime_compat-${{ version }}.tar.gz
       sha256: 6149aa764439cec26a5f883fb9921a50f61a0f6c4549df51c735626701a73a18
       target_directory: polars-runtime-compat
+      patches:
+        - 0001-bump-rustls-webpki.patch
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - package:


### PR DESCRIPTION
## Summary

Backports the Cargo.lock changes from [pola-rs/polars#27382](https://github.com/pola-rs/polars/pull/27382) (`chore(rust): Bump rustls-webpki`) as a recipe patch until those changes ship in a polars release.

The patch is applied to all three `polars-runtime-{32,64,compat}` sources (their `Cargo.lock` files are identical). The `docs/source/src/rust/Cargo.toml` portion of the upstream PR is omitted because that file is not present in the PyPI sdists.

Build number bumped from 0 to 1 per standard conda-forge policy.

## Checklist

- [x] Bumped build number
- [x] Verified patch applies cleanly to `polars_runtime_32-1.40.1`, `polars_runtime_64-1.40.1`, and `polars_runtime_compat-1.40.1` sdists
- [ ] CI passes